### PR TITLE
 Add new functionalities and improve code readability

### DIFF
--- a/src/lib/line.mbt
+++ b/src/lib/line.mbt
@@ -22,6 +22,23 @@ struct Point {
   mut y : Double
 }
 
+fn op_eq(self: Point, other: Point) -> Bool {
+  if self.x == other.x && self.y == other.y {
+    true
+  } else {
+    false
+  } 
+}
+
+fn op_add(self: Point, other: Point) -> Point {
+  {x : self.x + other.x, y : self.y + other.y}
+}
+
+fn op_sub(self: Point, other: Point) -> Point {
+  {x : self.x - other.x, y : self.y - other.y}
+}
+
+
 struct Line {
   mut a : Point
   b : Point

--- a/src/lib/sphere.mbt
+++ b/src/lib/sphere.mbt
@@ -32,16 +32,24 @@
 /// }
 /// ```
 fn angle(lng1 : Double, lat1 : Double, lng2 : Double, lat2 : Double) -> Double {
-    let mut dlng : Double = Double::abs(lng2 - lng1) * @math.PI / 180.0
-    while dlng >= @math.PI * 2.0 {
-        dlng -= @math.PI * 2.0
-    }
-    if dlng > @math.PI {
-        dlng = @math.PI * 2.0 - dlng
-    }
-    let lat11 : Double = lat1 * @math.PI / 180.0
-    let lat22 : Double = lat2 * @math.PI / 180.0
-    @math.acos(@math.sin(lat11) * @math.sin(lat22) + @math.cos(lat11) * @math.cos(lat22) * @math.cos(dlng))
+  let mut dlng : Double = Double::abs(lng2 - lng1) * @math.PI / 180.0
+  while dlng >= @math.PI * 2.0 {
+    dlng -= @math.PI * 2.0
+  }
+  if dlng > @math.PI {
+    dlng = @math.PI * 2.0 - dlng
+  }
+  let lat11 : Double = lat1 * @math.PI / 180.0
+  let lat22 : Double = lat2 * @math.PI / 180.0
+  let mut t = @math.sin(lat11) * @math.sin(lat22) +
+    @math.cos(lat11) * @math.cos(lat22) * @math.cos(dlng)
+  // 将 t 限制在 [-1, 1] 范围内
+  if t > 1.0 {
+    t = 1.0
+  } else if t < -1.0 {
+    t = -1.0
+  }
+  @math.acos(t)
 }
 
 ///|
@@ -76,17 +84,31 @@ fn angle(lng1 : Double, lat1 : Double, lng2 : Double, lat2 : Double) -> Double {
 ///   inspect!(Double::abs(dist - 2.0 * r) < 0.001, content="true")
 /// }
 /// ```
-fn line_dist(r : Double, lng1 : Double, lat1 : Double, lng2 : Double, lat2 : Double) -> Double {
-    let mut dlng : Double = Double::abs(lng2 - lng1) * @math.PI / 180.0
-    while dlng >= @math.PI * 2.0 {
-        dlng -= @math.PI * 2.0
-    }
-    if dlng > @math.PI {
-        dlng = @math.PI * 2.0 - dlng
-    }
-    let lat11 : Double = lat1 * @math.PI / 180.0
-    let lat22 : Double = lat2 * @math.PI / 180.0
-    r * Double::sqrt(2.0 - 2.0 * (@math.cos(lat11) * @math.cos(lat22) * @math.cos(dlng) + @math.sin(lat11) * @math.sin(lat22)))
+fn line_dist(
+  r : Double,
+  lng1 : Double,
+  lat1 : Double,
+  lng2 : Double,
+  lat2 : Double
+) -> Double {
+  let mut dlng : Double = Double::abs(lng2 - lng1) * @math.PI / 180.0
+  while dlng >= @math.PI * 2.0 {
+    dlng -= @math.PI * 2.0
+  }
+  if dlng > @math.PI {
+    dlng = @math.PI * 2.0 - dlng
+  }
+  let lat11 : Double = lat1 * @math.PI / 180.0
+  let lat22 : Double = lat2 * @math.PI / 180.0
+  r *
+  Double::sqrt(
+    2.0 -
+    2.0 *
+    (
+      @math.cos(lat11) * @math.cos(lat22) * @math.cos(dlng) +
+      @math.sin(lat11) * @math.sin(lat22)
+    ),
+  )
 }
 
 ///|
@@ -117,6 +139,12 @@ fn line_dist(r : Double, lng1 : Double, lat1 : Double, lng2 : Double, lat2 : Dou
 ///   inspect!(dist > 5569.0 && dist < 5571.0, content="true")
 /// }
 /// ```
-fn sphere_dist(r : Double, lng1 : Double, lat1 : Double, lng2 : Double, lat2 : Double) -> Double {
-    r * angle(lng1, lat1, lng2, lat2)
+fn sphere_dist(
+  r : Double,
+  lng1 : Double,
+  lat1 : Double,
+  lng2 : Double,
+  lat2 : Double
+) -> Double {
+  r * angle(lng1, lat1, lng2, lat2)
 }


### PR DESCRIPTION
This pull request includes several changes to the `src/lib/line.mbt` and `src/lib/sphere.mbt` files to add new functionalities and improve code readability. The most important changes include adding operator functions for the `Point` struct and refactoring the `angle`, `line_dist`, and `sphere_dist` functions.

### New functionalities for `Point` struct:
* [`src/lib/line.mbt`](diffhunk://#diff-7e8eea96494941113a023676e41ec7b38b3f3cd26d61554953df42df855fca00R25-R41): Added `op_eq`, `op_add`, and `op_sub` functions to the `Point` struct to enable equality checking, addition, and subtraction of `Point` instances.

### Refactoring for readability:
* [`src/lib/sphere.mbt`](diffhunk://#diff-b483597c95cbeb3b16cc36aaa4382e13246553dc885fd119e37d2e577dff7356L44-R52): Modified the `angle` function to clamp the value of `t` within the range [-1, 1] before passing it to the `acos` function.
* [`src/lib/sphere.mbt`](diffhunk://#diff-b483597c95cbeb3b16cc36aaa4382e13246553dc885fd119e37d2e577dff7356L89-R111): Refactored the `line_dist` function to improve readability by breaking down the calculation into multiple lines and adding appropriate indentation.
* [`src/lib/sphere.mbt`](diffhunk://#diff-b483597c95cbeb3b16cc36aaa4382e13246553dc885fd119e37d2e577dff7356L79-R93): Reformatted the `line_dist` function signature to have each parameter on a new line for better readability.
* [`src/lib/sphere.mbt`](diffhunk://#diff-b483597c95cbeb3b16cc36aaa4382e13246553dc885fd119e37d2e577dff7356L120-R148): Reformatted the `sphere_dist` function signature to have each parameter on a new line for better readability.